### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Layer Exporter for Adobe Illustrator
+# Layer Exporter for Adobe Illustrator
 
 
 
@@ -9,7 +9,7 @@ Layer Exporter lets you automatically export Illustrator layers to SVG, JPG or P
 
 It's a free & open source extension panel for Adobe Illustrator CC, made with the [creative cloud extensiblity helpers](http://davidderaedt.github.io/ccext-website/).
 
-##Install
+## Install
 
 CC extensions can either be installed via the built-in *Adobe Exchange Panel* (preferred method), or via a ZXP package executed in *Extension Manager CC* (which you must install first via the *Creative Cloud Desktop* application).
 
@@ -21,7 +21,7 @@ Alternatively, you can download and install the current production ZXP (stable) 
 
 
 
-##Exporting Images 
+## Exporting Images 
 
 This panel uses naming conventions to create the JPG, PNG or SVG files from your artwork. For instance, to export the content of your "Logo" layer, simply rename it to "Logo.png", and your `Logo.png` file will be created in your destination folder.
 
@@ -34,7 +34,7 @@ The *Options* panel will let you specify globally image format options such as J
 ![image](https://raw.githubusercontent.com/davidderaedt/Illustrator-Layer-Exporter/master/pics/p2.png)
 
 
-###Exporting Layers
+### Exporting Layers
 
 If you have a big file with many layers, renaming all those layers can be somewhat tedious. To help you with that renaming step, you can use the *Tools* panel to automatically rename all your layers so that they get exported to the appropriate file format.
 
@@ -43,7 +43,7 @@ If you have a big file with many layers, renaming all those layers can be somewh
 ![image](https://raw.githubusercontent.com/davidderaedt/Illustrator-Layer-Exporter/master/pics/p1.png)
 
 
-###Exporting art items
+### Exporting art items
 
 All art items (such as paths, texts and groups) inside layers can also be suffixed to be exported to image files, even if its parent layer has itself been renamed to be exported as an image file.
 
@@ -53,14 +53,14 @@ You can also use the *Move selected items* options to automatically create top l
 
 
 
-##Exporting composition data
+## Exporting composition data
 
 If you want to use exported image files somewhere (say, in a webpage or a native app), chances are you're going to need to get the coordinates of those elements in order to recreate the original composition.
 
 There several options to help you with that.
 
 
-###Exporting to HTML (static)
+### Exporting to HTML (static)
 
 
 If you want to export your whole composition to HTML, choose the corresponding option to generate an HTML file in the parent folder of destination folder for the images.
@@ -79,11 +79,11 @@ Here's what a typical HTML output could look like (go to the `samples` folder fo
 
 
 
-###Exporting to HTML (dynamic)
+### Exporting to HTML (dynamic)
 
 Alternatively, if you don't want to statically generate HTML and CSS code, you can choose to interpret the JSON file at runtime using javascript. You'll find sample code to help you do that in the `utils` folder of this repo, and a sample *lanscape* project in the `samples` folder.
 
-###Experimental HTML features
+### Experimental HTML features
 
 We're working on some additional features to help with HTML export. Since those features are experimental, they are likely to change in the future. Also, things will break.
 
@@ -93,7 +93,7 @@ We're working on some additional features to help with HTML export. Since those 
 For a full example of all those features, you can jump to the `samples` folder.
 
 
-###Edge Animate project
+### Edge Animate project
 
 Layer Exporter has (limited) support for Adobe's *Edge Animate* Projects.
 
@@ -103,7 +103,7 @@ The *Import to Edge Animate* option lets you choose an existing .an file and wil
 
 You'll find an empty Edge Animate project in the `utils` folder.
 
-###Exporting to other contexts
+### Exporting to other contexts
 
 
 Alternatively, you can choose to create a dump of the raw data of the composition so that you, a developer, or a 3rd party tool can interpret the data . Choose the `Create JSON data file` to create a JSON representation of the composition inside the image destination folder.
@@ -111,7 +111,7 @@ Alternatively, you can choose to create a dump of the raw data of the compositio
 ![image](https://raw.githubusercontent.com/davidderaedt/Illustrator-Layer-Exporter/master/pics/json.png)
 
 
-##Release notes
+## Release notes
 
 
 v 2.1.0 - May 28th 2014
@@ -149,45 +149,45 @@ V 1.0 - June 2013
 * data.json file describes the scene graph for 3rd party tools
 
 
-##Known issues
+## Known issues
 
 * Sublayers are not supported. Rationale: a recursive process could be used, but an Illustrator bug prevents from knowing the relative zorder of layers vs art items, making it impossible to create a proper representation of the whole composition.
 * Special items (divs backgrounds and texts) are not currently supported in edge animate export
 * Layer names cannot be set with the same UX as with art items (eg "set selected layers as PNG"). Rationale: the illustrator API does not let us know which layers are selected.
 
 
-##FAQ
+## FAQ
 
 
-###Why do I need Illustrator CC / 17.0+?
+### Why do I need Illustrator CC / 17.0+?
 Sorry, CC apps have a new engine for extensions which lets you create panels using nothing but web standards. This is what this panel uses. You can still port it by yourself, of course.
 
-###How can I convert my rectangles to simple divs?
+### How can I convert my rectangles to simple divs?
 
 Because it would be stupid to use image files for simple rectangles when you could use div, you can simply use a non-suffixed layer with a rectangle inside. Using the (experimental) background element feature, this layer will be converted to a div and the underlying rectangle will be use to set the CSS for the size and the color.
 
-###Can I inline SVG code in HTML rather than use img?
+### Can I inline SVG code in HTML rather than use img?
 
 Unfortunately, no. Illustrator's API does not expose the generated SVG code, it only allows to automate file export.
 
-###Hey, the exported SVG code sucks!
+### Hey, the exported SVG code sucks!
 While it does the job, the Illustrator SVG export engine is not so great in the first place. I highly recommend using SVGO for optimization.
 
-###Why doesn't it work with my appearances?
+### Why doesn't it work with my appearances?
 Sorry, appearances are not supported at this stage.
 
-###Does it support symbols?
+### Does it support symbols?
 Yes and no. Symbols instances will all be treated as separated image files.
 
-###What about sublayers?
+### What about sublayers?
 Not supported, amigos.
 
 
-##About the source code
+## About the source code
 
 This repository is the source for the panel. The underlying logic, written in ExtendScript, is located in the CSscript repository.
 
-##Special thanks to
+## Special thanks to
 
 * [Franck Payen](https://twitter.com/fr32c), the best tester in the world, for his invaluable help.
 * [Stephane Baril](https://twitter.com/sbaril) for his amazing expertise


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
